### PR TITLE
Fixed Jruby build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rubygems'
+require 'bundler/setup'
 require 'rake'
 
 require 'bundler/gem_tasks'

--- a/niceogiri.gemspec
+++ b/niceogiri.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = %w{--charset=UTF-8}
   s.extra_rdoc_files = %w{LICENSE README.md}
 
-  s.add_dependency "nokogiri", [">= 1.4.0"]
+  s.add_dependency "nokogiri", ["~> 1.4.6"]
 
   s.add_development_dependency "minitest", ["~> 1.7.1"]
   s.add_development_dependency "bundler", ["~> 1.0.0"]


### PR DESCRIPTION
  NOTE:
    \* Niceogiri is not compatible with 1.5.x at this time because of all
      of the changes from 1.4.x to 1.5.
    \* Bundler needs to be installed under jruby with 1.9 mode off (no \* --1.9)

  -- Lance and Taylor
